### PR TITLE
[Fix] Updating Python and networkx versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,21 +5,23 @@ description = "Python-based modeling and simulation framework for Edge Computing
 authors = ["Paulo Severo <paulo.severo@edu.pucrs.br>"]
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.10"
 Mesa = "^1.0.0"
-networkx = "2.6.2"
+networkx = "3.4.2"
 msgpack = "^1.0.4"
 
 [tool.poetry.dev-dependencies]
-black = "^22.8.0"
 mkdocs = "^1.3.1"
 mkdocs-material = "^8.4.2"
 mkdocstrings = "^0.19.0"
 mkdocstrings-python = "^0.7.1"
+
+[tool.poetry.group.dev.dependencies]
+black = "25.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.black]
-line-length = 130
+line-length = 160


### PR DESCRIPTION
Updating the project's base Python version from 3.7.1 to 3.10, and updating the following dependencies:
- NetworkX (from 2.6.2 to 3.4.2)
- Black (dev dependency, from 22.8.0 to 25.1.0)