### PR TITLE
Fix log file append behavior

### DIFF
--- a/edge_sim_py/simulator.py
+++ b/edge_sim_py/simulator.py
@@ -324,11 +324,11 @@ class Simulator(ComponentManager, Model):
                 os.makedirs(f"{self.logs_directory}")
 
             for key, value in self.agent_metrics.items():
-                with open(f"{self.logs_directory}/{key}.msgpack", "wb") as output_file:
+                with open(f"{self.logs_directory}/{key}.msgpack", "ab") as output_file:
                     output_file.write(msgpack.packb(value))
 
                 if clean_data_in_memory:
-                    value = []
+                    self.agent_metrics[key] = []
 
     def initialize_agent(self, agent: object) -> object:
         """Initializes an agent object.


### PR DESCRIPTION
The `dump_data_to_disk` method in the `Simulator` class is currently overwriting existing log files instead of appending to them.

The proposed solution is to change the file opening mode from "wb" (write binary) to "ab" (append binary) to ensure that new data is added to the existing log files. Additionally, the method will reset the stored metrics after dumping to avoid retaining old data.