### PR TITLE
Fix network flow serialization bug

### DIFF
--- a/edge_sim_py/components/network_flow.py
+++ b/edge_sim_py/components/network_flow.py
@@ -1,4 +1,5 @@
-""" Contains network-flow-related functionality."""
+"""Contains network-flow-related functionality."""
+
 # EdgeSimPy components
 from edge_sim_py.component_manager import ComponentManager
 
@@ -95,7 +96,7 @@ class NetworkFlow(ComponentManager, Agent):
         dictionary = {
             "id": self.id,
             "status": self.status,
-            "nodes": [{"type": type(node).__name__, "id": node.id} for node in self.nodes],
+            "nodes": [{"type": type(node).__name__, "id": node.id} for node in self.path],
             "path": self.path,
             "start": self.start,
             "end": self.end,


### PR DESCRIPTION
Apparently, the `NetworkFlow` class does not have a `nodes` attribute, at the same time, such inexistent attribute is used in the `_to_dict` method to serialize the flow's path. This will possibly lead to runtime errors when exporting flows.

The proposed fix is to iterate over the flow's `path` attribute instead, which is the correct attribute that contains the nodes in the flow's path.